### PR TITLE
Trovi 2.0: Create initial database models

### DIFF
--- a/trovi/fields.py
+++ b/trovi/fields.py
@@ -1,0 +1,32 @@
+import re
+from django.core import validators
+from django.core.validators import RegexValidator
+from django.db import models
+from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
+from typing import List
+
+
+class URNField(models.CharField):
+    """
+    Represents a database Uniform Resource Name
+    """
+
+    description = _("URN")
+    empty_strings_allowed = False
+    default_error_messages = {
+        "invalid": _("%(value)s invalid URN."),
+    }
+
+    # Validates that a URN follows the format described by
+    # https://datatracker.ietf.org/doc/html/rfc8141
+    pattern = re.compile(
+        r"^urn:(?P<NID>[a-z0-9-]{0,31}):(?P<NSS>[a-z0-9()+,\-.:=@;$_!*'%/?#]+)$",
+        flags=re.IGNORECASE,
+    )
+
+    @cached_property
+    def validators(self) -> List[validators.BaseValidator]:
+        return super(URNField, self).validators + [
+            RegexValidator(URNField.pattern, message=_("Enter a valid URN."))
+        ]

--- a/trovi/fields.py
+++ b/trovi/fields.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
-from typing import List
+from typing import List, Any
 
 
 class URNField(models.CharField):
@@ -32,3 +32,7 @@ class URNField(models.CharField):
         return super(URNField, self).validators + [
             RegexValidator(URNField.pattern, message=_("Enter a valid URN."))
         ]
+
+    def to_python(self, value: Any) -> str:
+        # This enforces that all URNs are converted to lowercase pre-write and post-read
+        return super(URNField, self).to_python(value).lower()

--- a/trovi/fields.py
+++ b/trovi/fields.py
@@ -1,9 +1,11 @@
 import re
+
 from django.core import validators
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+
 from typing import List
 
 

--- a/trovi/models.py
+++ b/trovi/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from fields import URNField
+from settings import ARTIFACT_SHARING_MAX_REPRO_REQUESTS
 
 
 class Artifact(models.Model):
@@ -18,7 +19,7 @@ class Artifact(models.Model):
     uuid = models.UUIDField(primary_key=True)
 
     # Descriptive information
-    title = models.CharField(max_length=200)
+    title = models.CharField(max_length=70)
     short_description = models.CharField(max_length=70, blank=True, null=True)
     long_description = models.TextField(max_length=5000)
 
@@ -33,7 +34,10 @@ class Artifact(models.Model):
     is_reproducible = models.BooleanField(default=False)
     repro_requests = models.IntegerField(
         default=0,
-        validators=[validators.MinValueValidator(0), validators.MaxValueValidator(10)],
+        validators=[
+            validators.MinValueValidator(0),
+            validators.MaxValueValidator(ARTIFACT_SHARING_MAX_REPRO_REQUESTS),
+        ],
     )
     repro_access_hours = models.IntegerField(null=True)
 
@@ -50,12 +54,17 @@ class ArtifactVersion(models.Model):
     id = models.IntegerField(primary_key=True)
     slug = models.SlugField(primary_key=True, max_length=12)
 
-    artifact_id = models.ForeignKey(
-        Artifact, models.CASCADE, related_name="artifact_version"
-    )
+    artifact = models.ForeignKey(Artifact, models.CASCADE, related_name="versions")
     created_at = models.DateTimeField(auto_now_add=True)
     contents_urn = URNField(max_length=255)
-    access_count = models.IntegerField(default=0)
+
+    @property
+    def access_count(self) -> int:
+        """
+        Shortcut for determining how many times an artifact version has been launched
+        :return: The number of LAUNCH events for this artifact version
+        """
+        return self.events.filter(event_type=ArtifactEvent.EventType.LAUNCH).count()
 
 
 class ArtifactEvent(models.Model):
@@ -68,11 +77,14 @@ class ArtifactEvent(models.Model):
 
     # The artifact version this event is for
     artifact_version = models.ForeignKey(
-        ArtifactVersion, models.CASCADE, related_name="artifact_event"
+        ArtifactVersion, models.CASCADE, related_name="events"
     )
 
     # The type of event
-    event_type = models.CharField(max_length=6, choices=EventType.choices)
+    event_type = models.CharField(
+        max_length=max(len(key) for key, _ in EventType.choices),
+        choices=EventType.choices,
+    )
     # The user who initiated the event
     event_origin = URNField(max_length=255, null=True)
 
@@ -83,17 +95,17 @@ class ArtifactEvent(models.Model):
 class ArtifactTag(models.Model):
     """Represents a searchable and sortable tag which can be applied to any artifact"""
 
-    artifact_id = models.ForeignKey(
-        Artifact, models.CASCADE, related_name="artifact_tag"
+    artifact = models.ForeignKey(
+        Artifact, models.CASCADE, related_name="tags"
     )
-    tag = models.CharField(max_length=32)
+    tag = models.CharField(max_length=32, unique=True)
 
 
 class ArtifactAuthor(models.Model):
     """Represents an author of an artifact"""
 
-    artifact_id = models.ForeignKey(
-        Artifact, models.CASCADE, related_name="artifact_author"
+    artifact = models.ForeignKey(
+        Artifact, models.CASCADE, related_name="author"
     )
     full_name = models.CharField(max_length=200)
     affiliation = models.CharField(max_length=200, blank=True, null=True)
@@ -103,7 +115,7 @@ class ArtifactAuthor(models.Model):
 class ArtifactProject(models.Model):
     """Represents the project associated with an artifact"""
 
-    artifact_id = models.ForeignKey(
-        Artifact, models.CASCADE, related_name="artifact_project"
+    artifact = models.ForeignKey(
+        Artifact, models.CASCADE, related_name="project"
     )
-    urn = URNField(max_length=255)
+    urn = URNField(max_length=255, unique=True)

--- a/trovi/models.py
+++ b/trovi/models.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 from fields import URNField
-from settings import ARTIFACT_SHARING_MAX_REPRO_REQUESTS
 
 
 class Artifact(models.Model):

--- a/trovi/models.py
+++ b/trovi/models.py
@@ -1,0 +1,86 @@
+import secrets
+
+from django.core import validators
+from django.db import models
+
+from fields import URNField
+
+
+class Artifact(models.Model):
+    """
+    Represents artifacts
+    These could be research projects, Zenodo depositions, etc.
+    """
+
+    # Identifiers
+    id = models.IntegerField(primary_key=True)
+    uuid = models.UUIDField(primary_key=True)
+
+    # Descriptive information
+    title = models.CharField(max_length=200)
+    short_description = models.CharField(max_length=70, blank=True, null=True)
+    long_description = models.TextField(max_length=5000)
+
+    # Timestamps
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    # Author who owns this Artifact
+    owner_urn = URNField(max_length=255)
+
+    # Experiment reproduction metadata
+    is_reproducible = models.BooleanField(default=False)
+    repro_requests = models.IntegerField(
+        default=0,
+        validators=[validators.MinValueValidator(0), validators.MaxValueValidator(10)],
+    )
+    repro_access_hours = models.IntegerField(null=True)
+
+    # Sharing metadata
+    sharing_key = models.CharField(
+        max_length=32, null=True, default=lambda: secrets.token_urlsafe(nbytes=32)
+    )
+
+
+class ArtifactVersion(models.Model):
+    """Represents a single published version of an artifact"""
+
+    # Identifiers
+    id = models.IntegerField(primary_key=True)
+    slug = models.SlugField(primary_key=True, max_length=12)
+
+    artifact_id = models.ForeignKey(
+        Artifact, models.CASCADE, related_name="artifact_version"
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    contents_urn = URNField(max_length=255)
+    access_count = models.IntegerField(default=0)
+
+
+class ArtifactTag(models.Model):
+    """Represents a searchable and sortable tag which can be applied to any artifact"""
+
+    artifact_id = models.ForeignKey(
+        Artifact, models.CASCADE, related_name="artifact_tag"
+    )
+    tag = models.CharField(max_length=32)
+
+
+class ArtifactAuthor(models.Model):
+    """Represents an author of an artifact"""
+
+    artifact_id = models.ForeignKey(
+        Artifact, models.CASCADE, related_name="artifact_author"
+    )
+    full_name = models.CharField(max_length=200)
+    affiliation = models.CharField(max_length=200, blank=True, null=True)
+    email = models.EmailField(max_length=254)
+
+
+class ArtifactProject(models.Model):
+    """Represents the project associated with an artifact"""
+
+    artifact_id = models.ForeignKey(
+        Artifact, models.CASCADE, related_name="artifact_project"
+    )
+    urn = URNField(max_length=255)

--- a/trovi/models.py
+++ b/trovi/models.py
@@ -1,5 +1,6 @@
 import secrets
 
+import uuid as uuid
 from django.core import validators
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -13,7 +14,7 @@ class Artifact(models.Model):
     These could be research projects, Zenodo depositions, etc.
     """
 
-    uuid = models.UUIDField(primary_key=True)
+    uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
     # Descriptive information
     title = models.CharField(max_length=70)
@@ -38,6 +39,15 @@ class Artifact(models.Model):
     repro_access_hours = models.IntegerField(null=True)
 
     # Sharing metadata
+    class Visibility(models.TextChoices):
+        PUBLIC = _("public")
+        PRIVATE = _("private")
+
+    visibility = models.CharField(
+        max_length=max(len(v) for v, _ in Visibility.choices),
+        choices=Visibility.choices,
+        default=Visibility.PRIVATE,
+    )
     sharing_key = models.CharField(
         max_length=32, null=True, default=lambda: secrets.token_urlsafe(nbytes=32)
     )

--- a/trovi/models.py
+++ b/trovi/models.py
@@ -2,6 +2,7 @@ import secrets
 
 from django.core import validators
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from fields import URNField
 
@@ -55,6 +56,28 @@ class ArtifactVersion(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     contents_urn = URNField(max_length=255)
     access_count = models.IntegerField(default=0)
+
+
+class ArtifactEvent(models.Model):
+    """Represents an event occurring on an artifact"""
+
+    class EventType(models.TextChoices):
+        LAUNCH = _("launch")
+        CITE = _("cite")
+        FORK = _("fork")
+
+    # The artifact version this event is for
+    artifact_version = models.ForeignKey(
+        ArtifactVersion, models.CASCADE, related_name="artifact_event"
+    )
+
+    # The type of event
+    event_type = models.CharField(max_length=6, choices=EventType.choices)
+    # The user who initiated the event
+    event_origin = URNField(max_length=255, null=True)
+
+    # The time at which the event occurred
+    timestamp = models.DateTimeField(auto_now_add=True)
 
 
 class ArtifactTag(models.Model):

--- a/trovi/models.py
+++ b/trovi/models.py
@@ -95,18 +95,14 @@ class ArtifactEvent(models.Model):
 class ArtifactTag(models.Model):
     """Represents a searchable and sortable tag which can be applied to any artifact"""
 
-    artifact = models.ForeignKey(
-        Artifact, models.CASCADE, related_name="tags"
-    )
+    artifact = models.ForeignKey(Artifact, models.CASCADE, related_name="tags")
     tag = models.CharField(max_length=32, unique=True)
 
 
 class ArtifactAuthor(models.Model):
     """Represents an author of an artifact"""
 
-    artifact = models.ForeignKey(
-        Artifact, models.CASCADE, related_name="author"
-    )
+    artifact = models.ForeignKey(Artifact, models.CASCADE, related_name="author")
     full_name = models.CharField(max_length=200)
     affiliation = models.CharField(max_length=200, blank=True, null=True)
     email = models.EmailField(max_length=254)
@@ -115,7 +111,5 @@ class ArtifactAuthor(models.Model):
 class ArtifactProject(models.Model):
     """Represents the project associated with an artifact"""
 
-    artifact = models.ForeignKey(
-        Artifact, models.CASCADE, related_name="project"
-    )
+    artifact = models.ForeignKey(Artifact, models.CASCADE, related_name="project")
     urn = URNField(max_length=255, unique=True)

--- a/trovi/models.py
+++ b/trovi/models.py
@@ -34,7 +34,6 @@ class Artifact(models.Model):
         default=0,
         validators=[
             validators.MinValueValidator(0),
-            validators.MaxValueValidator(ARTIFACT_SHARING_MAX_REPRO_REQUESTS),
         ],
     )
     repro_access_hours = models.IntegerField(null=True)
@@ -98,7 +97,7 @@ class ArtifactTag(models.Model):
 class ArtifactAuthor(models.Model):
     """Represents an author of an artifact"""
 
-    artifact = models.ForeignKey(Artifact, models.CASCADE, related_name="author")
+    artifact = models.ForeignKey(Artifact, models.CASCADE, related_name="authors")
     full_name = models.CharField(max_length=200)
     affiliation = models.CharField(max_length=200, blank=True, null=True)
     email = models.EmailField(max_length=254)
@@ -107,5 +106,19 @@ class ArtifactAuthor(models.Model):
 class ArtifactProject(models.Model):
     """Represents the project associated with an artifact"""
 
-    artifact = models.ForeignKey(Artifact, models.CASCADE, related_name="project")
+    artifact = models.ForeignKey(
+        Artifact, models.CASCADE, related_name="linked_projects"
+    )
     urn = URNField(max_length=255, unique=True)
+
+
+class ArtifactLink(models.Model):
+    """Represents a piece of data linked to an artifact"""
+
+    artifact_version = models.ForeignKey(
+        ArtifactVersion, models.CASCADE, related_name="links"
+    )
+    urn = URNField(max_length=255)
+    label = models.TextField(max_length=40)
+    verified_at = models.DateTimeField(auto_now=True)
+    verified = models.BooleanField(default=False)

--- a/trovi/models.py
+++ b/trovi/models.py
@@ -14,8 +14,6 @@ class Artifact(models.Model):
     These could be research projects, Zenodo depositions, etc.
     """
 
-    # Identifiers
-    id = models.IntegerField(primary_key=True)
     uuid = models.UUIDField(primary_key=True)
 
     # Descriptive information
@@ -50,8 +48,6 @@ class Artifact(models.Model):
 class ArtifactVersion(models.Model):
     """Represents a single published version of an artifact"""
 
-    # Identifiers
-    id = models.IntegerField(primary_key=True)
     slug = models.SlugField(primary_key=True, max_length=12)
 
     artifact = models.ForeignKey(Artifact, models.CASCADE, related_name="versions")

--- a/trovi/settings.py
+++ b/trovi/settings.py
@@ -73,6 +73,11 @@ ARTIFACT_SHARING_JUPYTERHUB_URL = os.getenv(
 ZENODO_URL = os.getenv("ZENODO_URL", "https://zenodo.org")
 ZENODO_DEFAULT_ACCESS_TOKEN = os.getenv("ZENODO_DEFAULT_ACCESS_TOKEN")
 
+# Artifact policy
+# Max reproduction requests should ideally never be lowered, only raised.
+# Lowering the value will require complex custom migration logic
+ARTIFACT_SHARING_MAX_REPRO_REQUESTS = 10
+
 #####
 #
 # Email Configuration


### PR DESCRIPTION
Implements the models as described by the Schema diagram in the Trovi 2.0 design doc. Also implements a new field `URNField` which is used to represent the various URNs used by the models.
