### PR TITLE
Trovi 2.0: Implement create and delete ArtifactVersion endpoints

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -19,17 +19,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.2.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "certifi"
@@ -52,7 +52,7 @@ pycparser = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.9"
+version = "2.0.10"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -82,16 +82,16 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "django"
-version = "3.2.11"
-description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+version = "4.0.1"
+description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 
 [package.dependencies]
-asgiref = ">=3.3.2,<4"
-pytz = "*"
+asgiref = ">=3.4.1,<4"
 sqlparse = ">=0.2.2"
+tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
@@ -128,6 +128,17 @@ doc = ["Sphinx (>=1.6.5,<2)", "sphinx-rtd-theme (>=0.1.9)"]
 lint = ["flake8", "pep8", "isort"]
 python-jose = ["python-jose (==3.0.0)"]
 test = ["cryptography", "pytest-cov", "pytest-django", "pytest-xdist", "pytest", "tox"]
+
+[[package]]
+name = "drf-extensions"
+version = "0.7.1"
+description = "Extensions for Django REST Framework"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+djangorestframework = ">=3.9.3"
 
 [[package]]
 name = "ecdsa"
@@ -270,7 +281,7 @@ python-versions = ">=3.5"
 [[package]]
 name = "os-service-types"
 version = "1.7.0"
-description = "Python library for consuming OpenStack service-types-authority data"
+description = "Python library for consuming OpenStack sevice-types-authority data"
 category = "main"
 optional = false
 python-versions = "*"
@@ -376,11 +387,11 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyrsistent"
-version = "0.18.0"
+version = "0.18.1"
 description = "Persistent/Functional/Immutable data structures"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "pytest"
@@ -459,7 +470,7 @@ python-versions = "*"
 
 [[package]]
 name = "requests"
-version = "2.26.0"
+version = "2.27.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
@@ -530,8 +541,16 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tzdata"
+version = "2021.5"
+description = "Provider of IANA time zone data"
+category = "main"
+optional = false
+python-versions = ">=2"
+
+[[package]]
 name = "urllib3"
-version = "1.26.7"
+version = "1.26.8"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -545,7 +564,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "3df277f6add46aff529da3ac73445ae86195699e0eeafef96dee9f5a78939af2"
+content-hash = "4c860253ba94cd591c3f574c2242178b1f3a9ae477bb004f0c0390bf00ee49ae"
 
 [metadata.files]
 asgiref = [
@@ -557,8 +576,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
-    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -617,8 +636,8 @@ cffi = [
     {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
-    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
+    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
+    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
 ]
 cmarkgfm = [
     {file = "cmarkgfm-0.6.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:02f14c7e77fcddf044df14cc227d7703027ee720bac719616ac505af29812b73"},
@@ -677,8 +696,8 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 django = [
-    {file = "Django-3.2.11-py3-none-any.whl", hash = "sha256:0a0a37f0b93aef30c4bf3a839c187e1175bcdeb7e177341da0cb7b8194416891"},
-    {file = "Django-3.2.11.tar.gz", hash = "sha256:69c94abe5d6b1b088bf475e09b7b74403f943e34da107e798465d2045da27e75"},
+    {file = "Django-4.0.1-py3-none-any.whl", hash = "sha256:7cd8e8a3ed2bc0dfda05ce1e53a9c81b30eefd7aa350e538a18884475e4d4ce2"},
+    {file = "Django-4.0.1.tar.gz", hash = "sha256:2485eea3cc4c3bae13080dee866ebf90ba9f98d1afe8fda89bfb0eb2e218ef86"},
 ]
 djangorestframework = [
     {file = "djangorestframework-3.13.1-py3-none-any.whl", hash = "sha256:24c4bf58ed7e85d1fe4ba250ab2da926d263cd57d64b03e8dcef0ac683f8b1aa"},
@@ -687,6 +706,10 @@ djangorestframework = [
 djangorestframework-simplejwt = [
     {file = "djangorestframework_simplejwt-5.0.0-py3-none-any.whl", hash = "sha256:ddcbeef51155d1e71410dde44b581c7e04cfb74776f5337661ac3ef4c0c367e6"},
     {file = "djangorestframework_simplejwt-5.0.0.tar.gz", hash = "sha256:30b10e7732395c44d21980f773214d2b9bdeadf2a6c6809cd1a7c9abe272873c"},
+]
+drf-extensions = [
+    {file = "drf-extensions-0.7.1.tar.gz", hash = "sha256:90abfc11a2221e8daf4cd54457e41ed38cd71134678de9622e806193db027db1"},
+    {file = "drf_extensions-0.7.1-py2.py3-none-any.whl", hash = "sha256:007910437e64aa1d5ad6fc47266a4ac4280e31761e6458eb30fcac7494ac7d4e"},
 ]
 ecdsa = [
     {file = "ecdsa-0.17.0-py2.py3-none-any.whl", hash = "sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676"},
@@ -795,27 +818,27 @@ pyparsing = [
     {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
 ]
 pyrsistent = [
-    {file = "pyrsistent-0.18.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:da6e5e818d18459fa46fac0a4a4e543507fe1110e808101277c5a2b5bab0cd2d"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5e4395bbf841693eaebaa5bb5c8f5cdbb1d139e07c975c682ec4e4f8126e03d2"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-win32.whl", hash = "sha256:527be2bfa8dc80f6f8ddd65242ba476a6c4fb4e3aedbf281dfbac1b1ed4165b1"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58a70d93fb79dc585b21f9d72487b929a6fe58da0754fa4cb9f279bb92369396"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4916c10896721e472ee12c95cdc2891ce5890898d2f9907b1b4ae0f53588b710"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:73ff61b1411e3fb0ba144b8f08d6749749775fe89688093e1efef9839d2dcc35"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-win32.whl", hash = "sha256:b29b869cf58412ca5738d23691e96d8aff535e17390128a1a52717c9a109da4f"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-win_amd64.whl", hash = "sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:772e94c2c6864f2cd2ffbe58bb3bdefbe2a32afa0acb1a77e472aac831f83427"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c1a9ff320fa699337e05edcaae79ef8c2880b52720bc031b219e5b5008ebbdef"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cd3caef37a415fd0dae6148a1b6957a8c5f275a62cca02e18474608cb263640c"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-win32.whl", hash = "sha256:e79d94ca58fcafef6395f6352383fa1a76922268fa02caa2272fff501c2fdc78"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-win_amd64.whl", hash = "sha256:a0c772d791c38bbc77be659af29bb14c38ced151433592e326361610250c605b"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d5ec194c9c573aafaceebf05fc400656722793dac57f254cd4741f3c27ae57b4"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:6b5eed00e597b5b5773b4ca30bd48a5774ef1e96f2a45d105db5b4ebb4bca680"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:48578680353f41dca1ca3dc48629fb77dfc745128b56fc01096b2530c13fd426"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-win32.whl", hash = "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-win_amd64.whl", hash = "sha256:404e1f1d254d314d55adb8d87f4f465c8693d6f902f67eb6ef5b4526dc58e6ea"},
-    {file = "pyrsistent-0.18.0.tar.gz", hash = "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win32.whl", hash = "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win_amd64.whl", hash = "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win32.whl", hash = "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win32.whl", hash = "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win32.whl", hash = "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07"},
+    {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
@@ -838,8 +861,8 @@ pytz = [
     {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
 ]
 requests = [
-    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
-    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 rsa = [
     {file = "rsa-4.8-py3-none-any.whl", hash = "sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb"},
@@ -865,7 +888,11 @@ toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
+tzdata = [
+    {file = "tzdata-2021.5-py2.py3-none-any.whl", hash = "sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5"},
+    {file = "tzdata-2021.5.tar.gz", hash = "sha256:68dbe41afd01b867894bbdfd54fa03f468cfa4f0086bfb4adcd8de8f24f3ee21"},
+]
 urllib3 = [
-    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
-    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
+    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
+    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -281,7 +281,7 @@ python-versions = ">=3.5"
 [[package]]
 name = "os-service-types"
 version = "1.7.0"
-description = "Python library for consuming OpenStack sevice-types-authority data"
+description = "Python library for consuming OpenStack service-types-authority data"
 category = "main"
 optional = false
 python-versions = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Chameleon Cloud <contact@chameleoncloud.org>"]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-Django = "^3.2.11"
+Django = "^4.0"
 djangorestframework = "^3.12.4"
 mysqlclient = "^2.0.3"
 jsonschema = "^4.4.0"
@@ -16,6 +16,7 @@ keystoneauth1 = "^4.4.0"
 python-jose = "^3.3.0"
 python-keycloak-client = "^0.2.3"
 djangorestframework-simplejwt = "^5.0.0"
+drf-extensions = "^0.7.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/trovi/api/schema.py
+++ b/trovi/api/schema.py
@@ -2,6 +2,33 @@ import jsonschema
 
 SchemaValidator = jsonschema.Draft202012Validator
 
+version_schema = {
+    "type": "object",
+    "properties": {
+        "contents": {
+            "type": "object",
+            "properties": {
+                "urn": {"type": "string", "format": "urn"},
+            },
+        },
+        "links": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "label": {"type": "string"},
+                    "urn": {"type": "string", "format": "urn"},
+                },
+                "required": ["label", "urn"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["contents"],
+    "additionalProperties": False,
+}
+
+CreateArtifactVersionSchema = SchemaValidator(version_schema)
 CreateArtifactSchema = SchemaValidator(
     {
         "type": "object",
@@ -47,31 +74,7 @@ CreateArtifactSchema = SchemaValidator(
                 "required": ["enable_requests"],
                 "additionalProperties": False,
             },
-            "version": {
-                "type": "object",
-                "properties": {
-                    "contents": {
-                        "type": "object",
-                        "properties": {
-                            "urn": {"type": "string", "format": "urn"},
-                        },
-                    },
-                    "links": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "label": {"type": "string"},
-                                "urn": {"type": "string", "format": "urn"},
-                            },
-                            "required": ["label", "urn"],
-                            "additionalProperties": False,
-                        },
-                    },
-                },
-                "required": ["contents"],
-                "additionalProperties": False,
-            },
+            "version": version_schema,
         },
         "required": ["title", "short_description"],
         "additionalProperties": False,

--- a/trovi/api/tests.py
+++ b/trovi/api/tests.py
@@ -409,7 +409,7 @@ class TestCreateArtifactVersion(APITestCase):
         self.assertEqual(artifact_don_quixote.uuid, model.artifact.uuid)
         self.assertIn(model, artifact_don_quixote.versions.all())
 
-    def test_link_to_non_existant_artifact(self):
+    def test_link_to_non_existent_artifact(self):
         fake_uuid = uuid.uuid4()
         while True:
             try:

--- a/trovi/api/urls.py
+++ b/trovi/api/urls.py
@@ -1,10 +1,15 @@
-from rest_framework import routers
+from rest_framework_extensions import routers
 
-from trovi.api.views import ArtifactViewSet
+from trovi.api.views import ArtifactViewSet, ArtifactVersionViewSet
 
-router = routers.SimpleRouter()
+router = routers.ExtendedSimpleRouter()
 
-router.register("", ArtifactViewSet)
+router.register("", ArtifactViewSet).register(
+    "versions",
+    ArtifactVersionViewSet,
+    basename="artifact-version",
+    parents_query_lookups=["artifact"],
+)
 
 urlpatterns = router.get_urls()
 
@@ -16,3 +21,6 @@ ListArtifact = "artifact-list"
 GetArtifact = "artifact-detail"
 CreateArtifact = "artifact-list"
 UpdateArtifact = "artifact-detail"
+
+CreateArtifactVersion = "artifact-version-list"
+DeleteArtifactVersion = "artifact-version-detail"

--- a/trovi/api/views.py
+++ b/trovi/api/views.py
@@ -1,10 +1,14 @@
 from functools import cache
+from typing import Mapping
 
-from django.db import transaction
+from django.db import transaction, models
+from django.db.models import QuerySet
+from requests.structures import CaseInsensitiveDict
 from rest_framework import viewsets, mixins
 from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from trovi.api import schema
 from trovi.api.filters import ListArtifactsOrderingFilter
@@ -12,13 +16,46 @@ from trovi.api.paginators import ListArtifactsPagination
 from trovi.api.parsers import JSONSchemaParser
 from trovi.api.patches import ArtifactPatch
 from trovi.api.permissions import SharedWithPermission
-from trovi.api.serializers import ArtifactSerializer
-from trovi.models import Artifact
+from trovi.api.serializers import ArtifactSerializer, ArtifactVersionSerializer
+from trovi.models import Artifact, ArtifactVersion
 from util.types import DummyRequest
 
 
+class APIViewSet(viewsets.GenericViewSet):
+    """
+    Implements generic behavior useful to all API views
+    """
+
+    action_schema_map: Mapping
+
+    @cache
+    def get_object(self) -> models.Model:
+        # This override caches ``get`` queries so the same object
+        # can be referenced in multiple functions without redundant database round-trips
+        return super(APIViewSet, self).get_object()
+
+    def get_queryset(self) -> QuerySet:
+        # This override ensures relevant objects in the database to maintain the same
+        # state for any operations which require that behavior.
+        qs = super(APIViewSet, self).get_queryset()
+        if self.action in ("list", "create", "partial_update"):
+            qs = qs.select_for_update()
+        return qs
+
+    def get_parser_context(self, http_request: Request) -> dict:
+        context = super(APIViewSet, self).get_parser_context(http_request)
+
+        # Since action has not been defined at this point, we determine the appropriate
+        # schema via the request method
+        if (json_schema := self.action_schema_map.get(self.request.method)) is not None:
+            context["schema"] = json_schema
+
+        return context
+
+
 class ArtifactViewSet(
-    viewsets.GenericViewSet,
+    NestedViewSetMixin,
+    APIViewSet,
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
@@ -112,6 +149,14 @@ class ArtifactViewSet(
     # JSON Patch used to provide update context to serializers
     patch = None
 
+    action_schema_map = CaseInsensitiveDict(
+        {
+            "POST": schema.CreateArtifactSchema,
+            "PATCH": schema.UpdateArtifactSchema,
+            "UPDATE": schema.UpdateArtifactSchema,
+        }
+    )
+
     @transaction.atomic
     def list(self, request: Request, *args, **kwargs) -> Response:
         return super(ArtifactViewSet, self).list(request, *args, **kwargs)
@@ -139,25 +184,13 @@ class ArtifactViewSet(
         # This method is implemented by the UpdateMixin to support the PUT method
         # We don't support full updates, so this endpoint is overridden here
         # to prevent it from being accessed.
-        if "partial" not in kwargs:
+        if not self.patch:
             raise MethodNotAllowed(
                 "Full Artifact updates are not supported for UpdateArtifact. "
                 "Please use PATCH with a properly formatted JSON Patch."
             )
         else:
             return super(ArtifactViewSet, self).update(request, *args, **kwargs)
-
-    def get_parser_context(self, http_request: Request) -> dict:
-        context = super(ArtifactViewSet, self).get_parser_context(http_request)
-
-        # Since action has not been defined at this point, we determine the appropriate
-        # schema via the request method
-        if (method := self.request.method.upper()) == "POST":
-            context["schema"] = schema.CreateArtifactSchema
-        elif method in ("PATCH", "UPDATE"):
-            context["schema"] = schema.UpdateArtifactSchema
-
-        return context
 
     def get_serializer_context(self):
         context = super(ArtifactViewSet, self).get_serializer_context()
@@ -167,16 +200,109 @@ class ArtifactViewSet(
 
         return context
 
-    def get_queryset(self):
-        # This override ensures relevant objects in the database to maintain the same
-        # state for any operations which require that behavior.
-        qs = super(ArtifactViewSet, self).get_queryset()
-        if self.action in ("list", "create", "partial_update"):
-            qs = qs.select_for_update()
-        return qs
 
-    @cache
-    def get_object(self):
-        # This override caches ``get`` queries so the same object
-        # can be referenced in multiple functions without redundant database round-trips
-        return super(ArtifactViewSet, self).get_object()
+class ArtifactVersionViewSet(
+    NestedViewSetMixin,
+    APIViewSet,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+):
+    """
+    Implements all endpoints at /artifacts/<uuid>/versions
+
+    CreateArtifactVersion (self.create):
+        POST /artifacts/<uuid>/versions
+        Associate a new Version to an Artifact.
+
+        Required scopes: artifact:write
+
+        Request body:
+            - contents (required):
+                - urn: a URN "contents:<backend>:<id>" where the ID depends on the
+                  backend:
+                    - chameleon: the ID is the object UUID of the artifact's tarball
+                      contents in Swift
+                    - zenodo: the ID is the DOI assigned by Zenodo
+                    - github: the ID is the GitHub repository with an optional Git
+                      reference (tag, branch) ({username|org}/{repo}[@{git_ref}])
+            - links[]:
+                - label: display name for the link
+                - location: URN describing the type of link ("disk_image" or "dataset")
+                  and its location; the precise structure can vary depending on where
+                  the link points to, e.g.:
+                    - disk_image:chameleon:CHI@UC:<uuid>: a Glance disk image located on
+                      Chameleon site CHI@UC.
+                    - disk_image:fabric:<hank>:<uuid>: a Glance disk image located on
+                      some Fabric hank.
+                    - dataset:globus:<endpoint>:<path>: a Globus data asset located on
+                      a given endpoint at a certain path
+                    - dataset:chameleon:CHI@UC:<path>: an object stored in the
+                      Chameleon object store at CHI@UC at a given path.
+                    - dataset:zenodo:<doi>:<path>: an asset published on Zenodo under
+                      a deposition with given DOI, within a given path inside
+                      that deposition.
+
+        Version Slug:
+        On creation, the artifact version is given a version slug derived from
+        the date published. It has the format:
+
+            YYYY-MM-DD[.#]
+                - YYYY: current year
+                - MM: current month, 0-padded
+                - DD: current day, 0-padded
+                - #: incrementing index, starting at 1. Increments automatically for
+                  each new version published on a given day. The 1st version published
+                  on a given day will not have this suffix;
+                  the 2nd version will be given suffix .1, and so on.
+
+        Unique contents
+        Two ArtifactVersions cannot reference the same contents;
+        if a second ArtifactVersion is created referencing the same contents URN
+        as one that already exists, a 409 Conflict error is raised.
+
+        Response: 201 Created
+        Example response body:
+        {
+          "slug": "2021-10-07.0",
+          "created_at": "2021-10-07T05:00Z",
+          "contents": {
+            "urn": "chameleon:108beeac-564f-4030-b126-ec4d903e680e"
+          },
+          "metrics": {
+            "access_count": 0
+          },
+          "links": [
+            {
+              "label": "Training data",
+              "verified": true,
+              "urn": "dataset:globus:979a1221-8c42-41bf-bb08-4a16ed981447:/training_set"
+            },
+            {
+              "label": "Our training image",
+              "verified": true,
+              "urn": "disk_image:chameleon:CHI@TACC:fd13fbc0-2d53-4084-b348-3dbd60cdc5e1"
+            }
+          ]
+        }
+
+
+    DeleteArtifactVersion (self.destroy):
+        DELETE /artifacts/<uuid>/versions/<version_slug>
+        Deletes a given Version of an Artifact.
+
+        Required scopes: artifact:write
+
+        Response: 204 No Content
+    """
+
+    queryset = ArtifactVersion.objects.all()
+    parser_classes = [JSONSchemaParser]
+    lookup_field = "slug__iexact"
+    serializer_class = ArtifactVersionSerializer
+    lookup_value_regex = "[^/]+"
+
+    action_schema_map = CaseInsensitiveDict(
+        {
+            "POST": schema.CreateArtifactVersionSchema,
+        }
+    )

--- a/trovi/common/exceptions.py
+++ b/trovi/common/exceptions.py
@@ -1,0 +1,7 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class ConflictError(APIException):
+    status_code = status.HTTP_409_CONFLICT
+    default_code = "unique"

--- a/trovi/models.py
+++ b/trovi/models.py
@@ -111,14 +111,17 @@ class ArtifactVersion(models.Model):
         if created:
             time_stamp = instance.created_at.strftime("%Y-%m-%d")
             with transaction.atomic():
-                versions_today = (
-                    ArtifactVersion.objects.filter(
-                        artifact__created_at__date=instance.created_at.date(),
-                        artifact_id=instance.artifact_id,
+                if instance.artifact:
+                    versions_today = (
+                        instance.artifact.versions.filter(
+                            artifact__created_at__date=instance.created_at.date(),
+                        )
+                        .exclude(slug__exact="")
+                        .select_for_update()
+                        .count()
                     )
-                    .select_for_update()
-                    .count()
-                )
+                else:
+                    versions_today = 0
                 if versions_today:
                     time_stamp += f".{versions_today}"
                 instance.slug = time_stamp

--- a/util/test.py
+++ b/util/test.py
@@ -4,6 +4,7 @@ Not meant to be robust, and mostly unvalidated, but helpful to avoid
 having to reference dicts with strings repeatedly in tests.
 """
 import datetime
+import logging
 import random
 import uuid
 from typing import Union, Optional, Iterable, Any
@@ -117,6 +118,7 @@ def cut_string(s: str, max_length: int) -> str:
     return s[: min(len(s), max_length)]
 
 
+logging.getLogger("faker.factory").setLevel(logging.INFO)
 fake = faker.Faker(faker.config.AVAILABLE_LOCALES)
 
 CHI_SITES = ["TACC", "UC", "NU"]


### PR DESCRIPTION
Trovi 2.0: Implement create and delete ArtifactVersion endpoints

This patch introduces two new endpoints to the `api` app. The endpoints are `CreateArtifactVersion` and `DeleteArtifactVersion`. `CreateArtifactEndpoint` is located at `/artifacts/<uuid>/versions/` and `DeleteArtifactVersion` is located at `/artifacts/<uuid>/versions/<slug>`.

`CreateArtifactVersion` takes the same body as the `version` property of the `CreateArtifactEndpoint`, and follows the same logic with a few workarounds to accommodate the slightly different Artifact states for both endpoints.

`DeleteArtifactVersion` uses the standard deletion code from Django REST Framework.

The URL Router has been replaced with an `ExtendedSimpleRouter` from the [Django REST Framework Extensions Plugin](http://chibisov.github.io/drf-extensions/docs/) in order to accommodate the new routing patterns, which require two lookups. The API ViewSets were also refactored to inherit from a generic `APIViewSet` class to share common functionality between the `ArtifactViewSet` and the `ArtifactVersionViewSet`.

## Other changes:
* ✅ Add new tests for version endpoints
* 🏷 Add `common` package
    * This packages houses the new `exceptions` module
* 🐛 Fix a bug with slug generation
* 🗲 Improve slug generation performance
* 🔇 Quiet faker logs in tests
* ➕ Take dependency on [`drf-extensions`](https://pypi.org/project/drf-extensions/)

