### PR TITLE
IncrArtifactVersionMetrics endpoint

### DIFF
--- a/trovi/api/patches.py
+++ b/trovi/api/patches.py
@@ -66,7 +66,7 @@ class ArtifactPatchMixin:
             "authors": self.walker(
                 lambda a: self._int_key_only(a, self._artifact_author_description)
             ),
-            # linked_projects is mutable, but only current owners can modify it
+            # linked_projects is mutable, but only admins can modify it
             # this is enforced by the ArtifactSerializer
             "linked_projects": self.walker(self._int_key_only),
             "reproducibility": {"enable_requests": None, "access_hours": None},

--- a/trovi/api/serializers.py
+++ b/trovi/api/serializers.py
@@ -216,7 +216,7 @@ class ArtifactVersionMetricsSerializer(serializers.Serializer):
                 event_origin=origin,
                 artifact_version=instance,
             )
-            instance.refresh_from_db()
+        instance.refresh_from_db()
         return instance
 
     def create(self, validated_data):

--- a/trovi/api/serializers.py
+++ b/trovi/api/serializers.py
@@ -206,11 +206,11 @@ class ArtifactVersionMetricsSerializer(serializers.Serializer):
         and then subtract them here to determine how many events need to be created.
         This is not a huge deal, but it's unnecessary work that is confusing.
         """
-        access_count = validated_data.pop("access_count", 1)
+        access_count = validated_data.pop("access_count", None)
         origin = validated_data["origin"]
         # We don't call bulk_create here, because it doesn't run any save signals
         # even though it persists the models to the database
-        for _ in range(access_count):
+        for _ in range(access_count or 0):
             ArtifactEvent.objects.create(
                 event_type=ArtifactEvent.EventType.LAUNCH,
                 event_origin=origin,

--- a/trovi/api/serializers.py
+++ b/trovi/api/serializers.py
@@ -206,11 +206,11 @@ class ArtifactVersionMetricsSerializer(serializers.Serializer):
         and then subtract them here to determine how many events need to be created.
         This is not a huge deal, but it's unnecessary work that is confusing.
         """
-        access_count = validated_data.pop("access_count", None)
+        access_count = validated_data.pop("access_count", 1)
         origin = validated_data["origin"]
         # We don't call bulk_create here, because it doesn't run any save signals
         # even though it persists the models to the database
-        for _ in range(access_count or 0):
+        for _ in range(access_count):
             ArtifactEvent.objects.create(
                 event_type=ArtifactEvent.EventType.LAUNCH,
                 event_origin=origin,

--- a/trovi/api/serializers.py
+++ b/trovi/api/serializers.py
@@ -204,7 +204,7 @@ class ArtifactVersionMetricsSerializer(serializers.Serializer):
         If we were to use this in the way update methods are typically used, we would
         need to add the metric from the version to the amount in the request,
         and then subtract them here to determine how many events need to be created.
-        This is not a huge deal, but it's unecessary work that is confusing.
+        This is not a huge deal, but it's unnecessary work that is confusing.
         """
         access_count = validated_data.pop("access_count", None)
         origin = validated_data["origin"]

--- a/trovi/api/tests.py
+++ b/trovi/api/tests.py
@@ -3,6 +3,7 @@ import os
 import random
 import uuid
 
+from django.conf import settings
 from django.db import models
 from django.http import JsonResponse
 from django.test import TestCase
@@ -19,6 +20,7 @@ from trovi.api.urls import (
     UpdateArtifact,
     CreateArtifactVersion,
     DeleteArtifactVersion,
+    IncrArtifactVersionMetrics,
 )
 from trovi.auth.providers import get_client_by_name
 from trovi.common.tokens import TokenTypes, JWT
@@ -27,6 +29,7 @@ from trovi.models import (
     ArtifactTag,
     ArtifactVersion,
 )
+from util.decorators import timed_lru_cache
 from util.test import (
     artifact_don_quixote,
     version_don_quixote_1,
@@ -38,8 +41,8 @@ class APITestCase(TestCase):
     renderer = JSONRenderer()
     maxDiff = None
 
-    def get_test_token(self, scopes: list[JWT.Scopes] = None) -> str:
-        # TODO have each test run once per provider
+    @timed_lru_cache(timeout=settings.AUTH_TROVI_TOKEN_LIFESPAN_SECONDS)
+    def get_test_token(self, scope: str = None) -> str:
         provider_name = "CHAMELEON_KEYCLOAK"
         keycloak = get_client_by_name(provider_name)
         test_username = os.getenv(f"{provider_name}_TEST_USER_USERNAME")
@@ -51,7 +54,7 @@ class APITestCase(TestCase):
             test_username, test_password, test_client_id, test_client_secret
         )
 
-        requesting_scopes = scopes if scopes else [JWT.Scopes.ARTIFACTS_READ]
+        requesting_scope = scope if scope else JWT.Scopes.ARTIFACTS_READ
 
         response = self.client.post(
             reverse("TokenGrant"),
@@ -60,7 +63,7 @@ class APITestCase(TestCase):
                 "grant_type": "token_exchange",
                 "subject_token": valid_token,
                 "subject_token_type": TokenTypes.JWT_TOKEN_TYPE.value,
-                "scope": " ".join(map(lambda s: s.value, requesting_scopes)),
+                "scope": requesting_scope,
             },
         )
 
@@ -72,10 +75,11 @@ class APITestCase(TestCase):
         return response.json()["access_token"]
 
     def authenticate_url(self, url: str, scopes: list[JWT.Scopes] = None) -> str:
+        scopes = scopes or [JWT.Scopes.ARTIFACTS_READ]
         return (
             url
             + ("?" if "?" not in url else "&")
-            + f"access_token={self.get_test_token(scopes=scopes)}"
+            + f"access_token={self.get_test_token(scope=' '.join(scopes))}"
         )
 
     def list_artifact_path(self):
@@ -114,6 +118,19 @@ class APITestCase(TestCase):
         return self.authenticate_url(
             reverse(DeleteArtifactVersion, args=[artifact_uuid, version_slug]),
             scopes=[JWT.Scopes.ARTIFACTS_WRITE],
+        )
+
+    def incr_artifact_version_metrics_path(
+        self, artifact_uuid: str, version_slug: str, metric: str, amount: int = None
+    ):
+        if amount:
+            amount_arg = f"&amount={amount}"
+        else:
+            amount_arg = ""
+        return self.authenticate_url(
+            f"{reverse(IncrArtifactVersionMetrics, args=[artifact_uuid, version_slug])}"
+            f"?metric={metric}&origin={self.get_test_token()}{amount_arg}",
+            scopes=[JWT.Scopes.ARTIFACTS_WRITE_METRICS],
         )
 
     def assertAPIModelContentEqual(self, actual: models.Model, expected: models.Model):
@@ -754,5 +771,55 @@ class TestDeleteArtifactVersion(APITestCase):
         pass
 
     def test_delete_artifact_version_not_author(self):
+        # TODO
+        pass
+
+
+class TestIncrArtifactVersionMetrics(APITestCase):
+    def test_endpoint_works(self):
+        try:
+            base_response = self.client.put(
+                self.incr_artifact_version_metrics_path(
+                    str(artifact_don_quixote.uuid), "foo", "access_count"
+                )
+            )
+            self.assertIsNotNone(base_response)
+        except Exception as e:
+            self.fail(e)
+
+    def do_access_count_test(self, amount: int = None):
+        version_don_quixote_1.refresh_from_db()
+        artifact_don_quixote.refresh_from_db()
+        target_version_access_count = version_don_quixote_1.access_count + (amount or 1)
+        target_artifact_access_count = artifact_don_quixote.access_count + (amount or 1)
+        base_response = self.client.put(
+            self.incr_artifact_version_metrics_path(
+                str(artifact_don_quixote.uuid),
+                version_don_quixote_1.slug,
+                "access_count",
+                amount=amount,
+            )
+        )
+
+        self.assertEqual(base_response.status_code, status.HTTP_204_NO_CONTENT)
+
+        version_don_quixote_1.refresh_from_db()
+        artifact_don_quixote.refresh_from_db()
+        self.assertEqual(
+            target_version_access_count,
+            version_don_quixote_1.access_count,
+            msg=f"{amount=}",
+        )
+        self.assertEqual(
+            target_artifact_access_count,
+            artifact_don_quixote.access_count,
+            msg=f"{amount=}",
+        )
+
+    def test_increment_access_count(self):
+        self.do_access_count_test()
+        self.do_access_count_test(amount=5)
+
+    def test_increment_metrics_permissions(self):
         # TODO
         pass

--- a/trovi/api/urls.py
+++ b/trovi/api/urls.py
@@ -24,3 +24,4 @@ UpdateArtifact = "artifact-detail"
 
 CreateArtifactVersion = "artifact-version-list"
 DeleteArtifactVersion = "artifact-version-detail"
+IncrArtifactVersionMetrics = "artifact-version-metrics"

--- a/trovi/auth/serializers.py
+++ b/trovi/auth/serializers.py
@@ -7,7 +7,6 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 from trovi.auth import providers
-from trovi.common.exceptions import InvalidClient
 from trovi.common.tokens import JWT, TokenTypes
 from util.types import JSON
 

--- a/trovi/common/permissions.py
+++ b/trovi/common/permissions.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from requests.structures import CaseInsensitiveDict
 from rest_framework import permissions, views
 from rest_framework.request import Request
@@ -27,8 +29,6 @@ class BaseScopedPermission(permissions.BasePermission):
         token = JWT.from_request(request)
         if not token:
             return required_scopes == {JWT.Scopes.ARTIFACTS_READ}
-        if token.is_admin():
-            return True
         if required_scopes is None:
             raise KeyError(
                 f"Required scopes not set for action {request.method} "
@@ -51,8 +51,6 @@ class ArtifactScopedPermission(BaseScopedPermission):
         token = JWT.from_request(request)
         if not token:
             return obj.visibility == Artifact.Visibility.PUBLIC
-        if token.is_admin():
-            return True
         # If the authenticated user is not the artifact owner,
         # they may not write to the artifact
         if token.to_urn() != obj.owner_urn:
@@ -70,10 +68,8 @@ class ArtifactVisibilityPermission(permissions.BasePermission):
     ) -> bool:
         is_public = obj.visibility == Artifact.Visibility.PUBLIC
         token = JWT.from_request(request)
-        if not token:
+        if not token or is_public:
             return is_public
-        if token.is_admin() or is_public:
-            return True
         sharing_key = request.query_params.get("sharing_key")
         if sharing_key:
             return sharing_key == obj.sharing_key
@@ -83,7 +79,7 @@ class ArtifactVisibilityPermission(permissions.BasePermission):
             return token.to_urn() == obj.owner_urn
 
 
-class ArtifactVersionVisibilityPermission(ArtifactVisibilityPermission):
+class ArtifactVersionVisibilityPermission(permissions.BasePermission):
     """
     Determines if a user has permission to view an ArtifactVersion
     """
@@ -95,7 +91,7 @@ class ArtifactVersionVisibilityPermission(ArtifactVisibilityPermission):
         return artifact_visibility.has_object_permission(request, view, obj.artifact)
 
 
-class ArtifactVersionScopedPermission(ArtifactScopedPermission):
+class ArtifactVersionScopedPermission(permissions.BasePermission):
     """
     Determines if the user's authorization scope permits them to interact with the
     ArtifactVersion in the way they desire.
@@ -108,6 +104,44 @@ class ArtifactVersionScopedPermission(ArtifactScopedPermission):
         return artifact_scope.has_object_permission(request, view, obj.artifact)
 
 
+class ArtifactVersionMetricsVisibilityPermission(permissions.BasePermission):
+    """
+    Determines if a USER has permission to increment artifact metrics.
+    """
+
+    def has_object_permission(
+        self, request: Request, view: views.View, obj: ArtifactVersion
+    ) -> bool:
+        """
+        Confirms that the origin user has permission to update
+        an artifact version's metrics
+        """
+        if obj.artifact.visibility == Artifact.Visibility.PUBLIC:
+            return True
+        sharing_key = request.query_params.get("sharing_key")
+        if sharing_key and sharing_key == obj.artifact.sharing_key:
+            return True
+        origin_jws = request.query_params.get("origin")
+        if not origin_jws:
+            return False
+        origin_token = JWT.from_jws(origin_jws)
+        return origin_token.to_urn() == obj.artifact.owner_urn
+
+
+class ArtifactVersionMetricsScopedPermission(permissions.BasePermission):
+    """
+    Determines if a SERVICE has permission to increment artifact metrics.
+    """
+
+    def has_permission(self, request: Request, view: views.View) -> bool:
+        """
+        The only users with permission to change metrics are admins. Only admins
+        are allowed to obtain the trovi:admin or artifacts:write_metrics scopes
+        """
+        token = JWT.from_request(request)
+        return JWT.Scopes.ARTIFACTS_WRITE_METRICS in token.scope
+
+
 class BaseMetadataPermission(permissions.BasePermission):
     """
     Base permissions for viewing API metadata
@@ -115,12 +149,24 @@ class BaseMetadataPermission(permissions.BasePermission):
 
     def has_permission(self, request: Request, view: views.View) -> bool:
         if request.method.upper() == "GET":
+            # Listing metadata is public
             return True
         else:
-            token = JWT.from_request(request)
-            return token and token.is_admin()
+            admin_permission = AdminPermission()
+            return admin_permission.has_permission(request, view)
 
 
 class IsAuthenticatedWithTroviToken(permissions.BasePermission):
     def has_permission(self, request: Request, view: views.View) -> bool:
         return JWT.from_request(request) is not None
+
+
+class AdminPermission(permissions.BasePermission):
+    def has_object_permission(
+        self, request: Request, view: views.View, obj: Any
+    ) -> bool:
+        return self.has_permission(request, view)
+
+    def has_permission(self, request: Request, view: views.View) -> bool:
+        token = JWT.from_request(request)
+        return token and token.is_admin()

--- a/trovi/common/tokens.py
+++ b/trovi/common/tokens.py
@@ -54,7 +54,11 @@ class JWT:
         TROVI_ADMIN = "trovi:admin"
 
         def is_write_scope(self) -> bool:
-            return self.value.endswith(":write") or self.value == self.TROVI_ADMIN
+            return self.value in (
+                self.ARTIFACTS_WRITE,
+                self.ARTIFACTS_WRITE_METRICS,
+                self.TROVI_ADMIN,
+            )
 
         def __eq__(self, other: Any) -> bool:
             if type(other) is str:

--- a/util/test.py
+++ b/util/test.py
@@ -333,15 +333,16 @@ class SampleDataTestRunner(DiscoverRunner):
     def setup_databases(self, **kwargs) -> list[Any]:
         names = super(SampleDataTestRunner, self).setup_databases(**kwargs)
         print("Generating test data...")
-        all_models = don_quixote + sum(
-            [generate_fake_artifact() for _ in range(100)], start=[]
-        )
+        all_models = sum([generate_fake_artifact() for _ in range(100)], start=[])
         try:
             with transaction.atomic():
+                for model in don_quixote:
+                    model.save()
                 for model in all_models:
                     model.save()
-            with transaction.atomic():
-                generate_many_to_many(Artifact.objects.all())
+                generate_many_to_many(
+                    Artifact.objects.exclude(uuid=artifact_don_quixote.uuid)
+                )
         except IntegrityError as e:
             assert False, str(e)
         print("Finished.")


### PR DESCRIPTION
Follows the design of the architecture doc. Also add a parameter `amount` which allows bulk-creation of events.

The `artifacts:write_metrics` scope is now only issuable to admin users. In the future, this will be downgraded to service accounts.

Fix a bug in the testing infrastructure which was causing created events to be reverted in transactions.
