### PR TITLE
Remove Zenodo check for artifact

### DIFF
--- a/trovi/storage/backends/zenodo.py
+++ b/trovi/storage/backends/zenodo.py
@@ -96,11 +96,6 @@ class ZenodoBackend(StorageBackend):
         super(ZenodoBackend, self).__init__(name, *args, **kwargs)
         self.access_token = settings.ZENODO_DEFAULT_ACCESS_TOKEN
         self.version = version
-        if not self.version.artifact:
-            raise ValidationError(
-                "Cannot upload content to Zenodo "
-                "that is not associated with an artifact"
-            )
         if not self.content_id:
             if version.has_doi():
                 self.content_id = version.contents_urn.split(":")[-1]


### PR DESCRIPTION
This was causing a 400 when trying to get the contents without
using the full endpoint with artifact and version. Regardless, this
should work for either endpoint.

This check didn't seem to be required, there is no where in the backend
that uses the version or artifact.