### PR TITLE
Fix race condition in version slug generation

### DIFF
--- a/trovi/models.py
+++ b/trovi/models.py
@@ -299,14 +299,12 @@ class ArtifactVersion(models.Model):
             time_stamp = instance.created_at.strftime("%Y-%m-%d")
             with transaction.atomic():
                 if instance.artifact:
-                    versions_today = (
-                        instance.artifact.versions.filter(
-                            artifact__created_at__date=instance.created_at.date(),
-                        )
-                        .exclude(slug__exact="")
-                        .select_for_update()
-                        .count()
-                    )
+                    versions_today_query = instance.artifact.versions.filter(
+                        artifact__created_at__date=instance.created_at.date(),
+                    ).select_for_update()
+                    versions_today = versions_today_query.exclude(
+                        slug__exact=""
+                    ).count()
                 else:
                     versions_today = 0
                 if versions_today:


### PR DESCRIPTION
The previous use of `select_for_update` fell out of scope too quickly and caused the lock on the database to be removed too quickly. This potentially allowed a race condition if, for example, a user hit the "Create new version" button too many times and the queries were evaluated at the same time. It is possible that this caused the duplicate slug issue that we've observed before, in some cases.
