### PR TITLE
Correct command syntax for test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,4 @@ requirements-frozen.txt: build
 
 .PHONY: tests
 tests: .env
-	docker-docker -f ./tests-compose.yml run manage.py test
+	docker-compose -f ./tests-compose.yml run trovi test


### PR DESCRIPTION
Running of tests was failing due to a typo in the Docker command within the Makefile. This commit fixes the typo and updates the command to the correct syntax.
