### PR TITLE
Support tag[] query param to handle FE array serialization

### DIFF
--- a/trovi/api/filters.py
+++ b/trovi/api/filters.py
@@ -227,6 +227,11 @@ class ArtifactTagFilter(filters.BaseFilterBackend):
         self, request: Request, queryset: models.QuerySet, view: views.View
     ) -> models.QuerySet:
         tags = request.query_params.getlist(self.tag_param)
+
+        # Fallback for bracket syntax: ?tag[]=foo
+        if not tags:
+            tags = request.query_params.getlist(f"{self.tag_param}[]")
+
         if not tags:
             return queryset
 


### PR DESCRIPTION
Sorry for the stream of fixes. Now that the BE is faster and FE is updated, I noticed that the way the FE sends the tag query parameter isn't as straightforward as my initial implementation so we need to handle this case. Now the tag filter for the backend should work as expected.