### PR TITLE
Switch http storage backend from http download to git clone

### DIFF
--- a/trovi/api/admin.py
+++ b/trovi/api/admin.py
@@ -301,6 +301,7 @@ class AutoCrawledArtifactAdmin(admin.ModelAdmin):
             arguments = {}
             arguments["url"] = settings.ARTIFACT_JUPYTERHUB_DEFAULT_URL
             arguments["repo_url"] = crawled_artifact.source_url
+            arguments["protocol"] = "git"
 
             ArtifactVersionSetup.objects.create(
                 artifact_version=version,


### PR DESCRIPTION
This appears to do the trick so it clones the git repo pointed to by the external artifacts instead of downloading it as a webpage.